### PR TITLE
fix: table content is not renewed after opening another block

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,12 @@ logseq.ready().then(() => {
       logseq.showMainUI()
     })
   })
+
+  logseq.on('ui:visible:changed', (e) => {
+    if (!e.visible) {
+      ReactDOM.unmountComponentAtNode(document.getElementById('root'));
+    }
+  });
 })
 
 const renderApp = (initialTableContent, blockId) => {


### PR DESCRIPTION
## Steps to reproduce:

1. Open table editor at block A
2. Close the modal
3. Open table editor at another block B
4. We can see the content is still showing content at A

The root cause is that after the initial content is only rendered at the first time.